### PR TITLE
Change `start_safe` to `start`, add safeguards to `load` 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --statistics
         # run mypy for type checking
         mypy
     # TODO: implement pytest (will require mock):

--- a/example.py
+++ b/example.py
@@ -64,8 +64,9 @@ def main():
         j.set_time(120)
         return j
 
-    # if --cont command line argument called, load previous job
-    # otherwise create jobs
+    # if --cont command line argument called or user confirmed
+    # loading for existing `cfg.dir` above, load previous jobs
+    # otherwise create new jobs
     if cfg.cont:
         mgr.load()
     else:
@@ -94,9 +95,9 @@ def main():
     # start the manager
     # if there is an error, especially interupt with keyboard,
     # saves the current state of jobs
-    mgr.start_safe(60, gui=False)  # argument is interval between checking of the jobs
-    mgr.print_failed()
+    mgr.start(60, gui=False)  # argument is interval between checking of the jobs
     mgr.save()
+    mgr.print_failed()
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,14 @@ author = Filip Nechansky
 description = job manager and interface for htcondor
 #long_description = file: README.md
 #long_description_content_type = text/markdown
-#url = 
+#url =
 classifiers =
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
 

--- a/src/falconry/manager.py
+++ b/src/falconry/manager.py
@@ -64,7 +64,7 @@ class manager:
         self.jobs[j.name] = j
 
     # save current status
-    def save(self, quiet = False):
+    def save(self, quiet: bool = False):
         if not quiet:
             log.info("Saving current status of jobs")
         output: Dict[str, Any] = {}
@@ -365,4 +365,3 @@ class manager:
                     "Change your scripts as `start_safe` will be removed "
                     "in next version!")
         self.start_safe(sleepTime, gui)
-    


### PR DESCRIPTION
Change `start_safe` to `start`, add safeguards to `load`  against crashes/interruptions

Also `start` was renamed to `start_cli`. Given the setup anyone who used `start` before will be automatically forwarded to the function anyway, just with the `try` safequards.

Other:
 - Remove python3.6 from CI/official version as it is no longer supported
 - Added python 3.9, 3.10, 3.11
 - manager.check_resubmit -> fix bug for retry of badly submitted jobs.
 - manager.load
   + moved dependency loading out of the with file
   + retrying now safeguarded and status is saved on interruption, crash
   + also improved description
 - example.py:
   + `start_safe` -> `start
   + Improve comments
   + Change order of mgr operations since we want to save before doing possible lengthy printout

Clean-up:
Main change is refactoring of job.get_status to avoid
too many nested ifs. Checking of a log file was moved
to separate function `_get_status_log`. `get_condor_status`
was renamed to `_get_status_condor` to make explicit its meant
to be only internal.

Changed CI that for flake8 warning run, complexity and
max line length is taken from project settings.