### PR TITLE
Move to submission of multiple jobs per cluster

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,18 +3,24 @@
 import logging
 from falconry import manager, job
 
-logging.basicConfig(
-    level=logging.INFO, format="%(levelname)s (%(name)s): %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s (%(name)s): %(message)s")
 log = logging.getLogger(__name__)
 
 
 # using argparse to get command line arguments
 def config():
     import argparse
+
     parser = argparse.ArgumentParser(description="Falconry. Read README!")
-    parser.add_argument("--debug", action="store_true", help="Debug mode with more verbose printout")
-    parser.add_argument("--dir", type=str, help="Path to output DIR. Output by default.", default="Output")
+    parser.add_argument(
+        "--debug", action="store_true", help="Debug mode with more verbose printout"
+    )
+    parser.add_argument(
+        "--dir",
+        type=str,
+        help="Path to output DIR. Output by default.",
+        default="Output",
+    )
     return parser.parse_args()
 
 
@@ -32,7 +38,9 @@ def main():
     # It is alway useful to save the printounts to a log file
     file_handler = logging.FileHandler(cfg.dir + "/falconry.log", mode="a")
     dt_fmt = '%Y-%m-%d %H:%M:%S'
-    formatter = logging.Formatter('[{asctime}] [{levelname:<8}] {name}: {message}', dt_fmt, style='{')
+    formatter = logging.Formatter(
+        '[{asctime}] [{levelname:<8}] {name}: {message}', dt_fmt, style='{'
+    )
     file_handler.setFormatter(formatter)
     log.addHandler(file_handler)
 
@@ -59,7 +67,7 @@ def main():
         j = job(name, mgr.schedd)
 
         # set the executable and the path to the log files
-        j.set_simple(exe, cfg.dir+"/log/")
+        j.set_simple(exe, cfg.dir + "/log/")
 
         # set the expected run time in seconds
         j.set_time(120)
@@ -78,11 +86,16 @@ def main():
         depS = [j]
 
         j = simple_job("error", "util/echoE.sh")
-        # here we let manager to handle the submition
+        # Here we let manager to handle the submition
+        # They should be submitted automatically
+        # to the same cluster
         mgr.add_job(j)
         depE = [j]
+        j = simple_job("error2", "util/echoE.sh")
+        mgr.add_job(j)
+        depE.append(j)
 
-        # add job depending on the two submitted job to demonstrate what happens if depending job fails or succeds
+        # add job depending on the submitted job to demonstrate what happens if depending job fails or succeds
         j = simple_job("success_depS", "util/echoS.sh")
         j.add_job_dependency(*depS)
         mgr.add_job(j)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -10,7 +10,7 @@ def test_job():
     j.set_simple("my_script.sh", "log")
     assert j.name == "test"
     assert j.schedd == schedd
-    assert j.clusterIDs == []
+    assert j.jobIDs == []
     assert j.release() is False
     assert j.remove() is False
     assert j.submitted is False
@@ -22,9 +22,9 @@ def test_job():
 
     j.submit()
     assert j.submitted is True
-    assert len(j.clusterIDs) == 1
-    assert j.clusterIDs[0] == 1
-    assert j.clusterID == 1
+    assert len(j.jobIDs) == 1
+    assert j.jobIDs[0] == "1.0"
+    assert j.jobID == "1.0"
 
     assert j.remove() is True
     assert j.get_info()["JobStatus"] == -999
@@ -32,10 +32,10 @@ def test_job():
 
     j.submit()
     assert j.submitted
-    assert len(j.clusterIDs) == 2
-    assert j.clusterIDs[0] == 1
-    assert j.clusterIDs[1] == 2
-    assert j.clusterID == 2
+    assert len(j.jobIDs) == 2
+    assert j.jobIDs[0] == "1.0"
+    assert j.jobIDs[1] == "2.0"
+    assert j.jobID == "2.0"
     assert j.get_status() == FalconryStatus.IDLE
     assert j.get_info()["JobStatus"] == j.get_status().value
 
@@ -61,6 +61,7 @@ def test_manager():
     c = Counter()
 
     assert mgr._single_check(c) is True
+    mgr._submit_jobs()
     assert j.get_status() == FalconryStatus.IDLE
     schedd.run_jobs()
     assert mgr._single_check(c) is True


### PR DESCRIPTION
Imporant PR! Moves to submitting all compatible jobs within the same cluster which is much more optimal. This is limited to jobs with the same executable and log file (up to cluster/proc ID)
- the former is checked automatically, one could also consider to have "falconry" executable which simply calls whatever is needed from within, but shoudl be fine as is 
- to satisfy the log file path being same up to the cluster / proc ID, all log files are now put into the same directory and `falconry` creates soft link for the lastest in the original directory

On the technical side:
1) job submit has option to not actually submit, just prepare everything needed
2) manager then does not submit jobs right away, but puts them in new queue, which is submitted once per check
  - here all jobs with teh same executable are grouped together and submitted to single cluster.

This also means that we need to distinquish proc ID - thankfully there is simply `jobId` now in condor so we can still handle one number