### PR TITLE
Fix counter comparion to less clutter stdout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "falconry"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
   { name="Filip Nechansky", email="filip.nechansky@protonmail.com" },
 ]

--- a/src/falconry/manager.py
+++ b/src/falconry/manager.py
@@ -9,7 +9,7 @@ import datetime
 import select
 from time import sleep
 import htcondor
-from glob import glob
+import copy
 
 from typing import Dict, Any, Tuple, Optional
 
@@ -24,6 +24,9 @@ log = logging.getLogger('falconry')
 class Counter:
     # just holds few variables used in status print
     def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
         self.waiting = 0
         self.notSub = 0
         self.idle = 0
@@ -548,8 +551,8 @@ class manager:
             f"|-Checking status of jobs [{datetime.datetime.now()}]----------------|",
         )
 
-        cOld = c
-        c = Counter()
+        cOld = copy.copy(c)
+        c.reset()
         self._count_jobs(c)
 
         # if no job is waiting nor running, finish the manager


### PR DESCRIPTION
This was broken at some point where the old counter was never propagated back so it was always at 0, leading to the counter comparison always coming out false....